### PR TITLE
RFC: add channel_map and version to codebook

### DIFF
--- a/examples/codebook/codebook.json
+++ b/examples/codebook/codebook.json
@@ -1,24 +1,37 @@
-[
-  {
-    "codeword": [
-      {"r": 0, "c": 0, "v": 1},
-      {"r": 0, "c": 1, "v": 1},
-      {"r": 1, "c": 1, "v": 1}
-    ],
-    "target": "SCUBE2"
-  },
-  {
-    "codeword": [
-      {"r": 0, "c": 0, "v": 1},
-      {"r": 1, "c": 1, "v": 1}
-    ],
-    "target": "BRCA"
-  },
-  {
-    "codeword": [
-      {"r": 0, "c": 1, "v": 1},
-      {"r": 1, "c": 0, "v": 1}
-    ],
-    "target": "ACTB"
-  }
-]
+{
+  "codes": [
+    {
+      "codeword": [
+        {"r": 0, "c": 0, "v": 1},
+        {"r": 0, "c": 1, "v": 1},
+        {"r": 1, "c": 1, "v": 1}
+      ],
+      "target": "SCUBE2"
+    },
+    {
+      "codeword": [
+        {"r": 0, "c": 0, "v": 1},
+        {"r": 1, "c": 1, "v": 1}
+      ],
+      "target": "BRCA"
+    },
+    {
+      "codeword": [
+        {"r": 0, "c": 1, "v": 1},
+        {"r": 1, "c": 0, "v": 1}
+      ],
+      "target": "ACTB"
+    }
+  ],
+  "channel_map": [
+    {
+      "channel": "cy5",
+      "index": 0
+    },
+    {
+      "channel": "cy3",
+      "index": 1
+    }
+  ],
+  "version": "0.1.0"
+}

--- a/examples/codebook/codebook_diagonal.json
+++ b/examples/codebook/codebook_diagonal.json
@@ -1,20 +1,37 @@
-[
-  {
-    "codeword": [
-      {"c": 0, "v": 1}
-    ],
-    "target": "SCUBE2"
-  },
-  {
-    "codeword": [
-      {"c": 1, "v": 1}
-    ],
-    "target": "BRCA"
-  },
-  {
-    "codeword": [
-      {"c": 2, "v": 1}
-    ],
-    "target": "ACTB"
-  }
-]
+{
+  "codes": [
+    {
+      "codeword": [
+        {"c": 0, "v": 1}
+      ],
+      "target": "SCUBE2"
+    },
+    {
+      "codeword": [
+        {"c": 1, "v": 1}
+      ],
+      "target": "BRCA"
+    },
+    {
+      "codeword": [
+        {"c": 2, "v": 1}
+      ],
+      "target": "ACTB"
+    }
+  ],
+  "channel_map": [
+    {
+      "channel": "cy5",
+      "index": 0
+    },
+    {
+      "channel": "cy3",
+      "index": 1
+    },
+    {
+      "channel": "rCherry",
+      "index": 2
+    }
+  ],
+  "version": "0.1.0"
+}

--- a/examples/codebook/codebook_diagonal_inferred_value.json
+++ b/examples/codebook/codebook_diagonal_inferred_value.json
@@ -1,14 +1,31 @@
-[
-  {
-    "codeword": [{"c": 0}],
-    "target": "SCUBE2"
-  },
-  {
-    "codeword": [{"c": 1}],
-    "target": "BRCA"
-  },
-  {
-    "codeword": [{"c": 2}],
-    "target": "ACTB"
-  }
-]
+{
+  "codes": [
+    {
+      "codeword": [{"c": 0}],
+      "target": "SCUBE2"
+    },
+    {
+      "codeword": [{"c": 1}],
+      "target": "BRCA"
+    },
+    {
+      "codeword": [{"c": 2}],
+      "target": "ACTB"
+    }
+  ],
+  "channel_map": [
+    {
+      "channel": "cy5",
+      "index": 0
+    },
+    {
+      "channel": "cy3",
+      "index": 1
+    },
+    {
+      "channel": "rCherry",
+      "index": 2
+    }
+  ],
+  "version": "0.1.0"
+}

--- a/schema/codebook/channel_map.json
+++ b/schema/codebook/channel_map.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/spacetx/sptx-format/schema/codebook/channel_map.json",
+  "description": "A map between channels and the indexes that are used to represent them in codebook codes.",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "channel": {
+        "type": "string",
+        "description": "name of the channel"
+      },
+      "index": {
+        "type": "integer",
+        "description": "the is the number that represents this channel in the codebook codes object"
+      }
+    }
+  }
+}

--- a/schema/codebook/codebook.json
+++ b/schema/codebook/codebook.json
@@ -1,25 +1,42 @@
 {
   "$id": "https://github.com/spacetx/sptx-format/schema/codebook/codebook.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "array",
-  "minItems": 1,
-  "items": {
-    "type": "object",
-    "required": [
-      "codeword",
-      "target"
-    ],
-    "properties": {
-      "codeword": {
-        "$ref": "schema/codebook/codeword.json"
-      },
-      "target": {
-        "type": "string",
-        "description": "the target molecule (often gene or protein) identified by a codeword",
-        "examples": [
-          "ACTB", "CD4"
-        ]
+  "type": "object",
+  "required": [
+    "codes",
+    "channel_map",
+    "version"
+  ],
+  "properties": {
+    "codes" : {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "codeword",
+          "target"
+        ],
+        "properties": {
+          "codeword": {
+            "$ref": "schema/codebook/codeword.json"
+          },
+          "target": {
+            "type": "string",
+            "description": "the target molecule (often gene or protein) identified by a codeword",
+            "examples": [
+              "ACTB",
+              "CD4"
+            ]
+          }
+        }
       }
+    },
+    "channel_map" : {
+      "$ref": "schema/codebook/channel_map.json"
+    },
+    "version": {
+      "$ref": "schema/version.json"
     }
   }
 }

--- a/validate_sptx/test_codebook.py
+++ b/validate_sptx/test_codebook.py
@@ -34,6 +34,6 @@ def test_codebook_missing_channel_raises_validation_error():
         package_root, 'examples', 'codebook', 'codebook.json'
     )
     codebook = validator.load_json(codebook_example_path)
-    del codebook[0]['codeword'][0]['c']
+    del codebook['codes'][0]['codeword'][0]['c']
     with pytest.warns(UserWarning):
         assert not validator.validate_object(codebook)


### PR DESCRIPTION
This PR is a first attempt at adding a version and code_map to the codebook. Note that the diff is much smaller than git makes it appear -- to add properties to the codebook it needed to be converted from an `array` to an `object`, which caused it to get shifted up a level. 

See examples for the proposed codebook structure. 

@berl does this address the concern about being able to detect the channels? 

Addresses #3, #10