### PR TITLE
fix incorrect ID fields in codeword

### DIFF
--- a/schema/codebook/codeword.json
+++ b/schema/codebook/codeword.json
@@ -1,13 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/spacetx/sptx-format/schema/codebook.json/items/properties/codeword",
+  "$id": "https://github.com/spacetx/sptx-format/schema/codebook/codeword.json",
   "description": "definition of a code that maps a target to intensities over imaging rounds and channels",
   "type": [
     "array"
   ],
   "minItems": 1,
   "items": {
-    "$id": "https://github.com/spacetx/sptx-format/schema/codebook.json/items/properties/codeword/items",
     "type": [
       "object"
     ],
@@ -21,7 +20,6 @@
     "description": "an individual code mapping a target to an intensity observed in one channel in one imaging round",
     "properties": {
       "r": {
-        "$id": "https://github.com/spacetx/sptx-format/schema/codebook.json/items/properties/codeword/items/properties/r",
         "type": [
           "integer",
           "null"
@@ -34,7 +32,6 @@
         ]
      },
       "c": {
-        "$id": "https://github.com/spacetx/sptx-format/schema/codebook.json/items/properties/codeword/items/properties/c",
         "type": "integer",
         "description": "an integer that maps to the channel a given code entry is read from",
         "minimum": 0,
@@ -43,7 +40,6 @@
         ]
      },
       "v": {
-        "$id": "https://github.com/spacetx/sptx-format/schema/codebook.json/items/properties/codeword/items/properties/v",
         "type": [
           "number",
           "null"


### PR DESCRIPTION
* The top-level id of codeword.json was pointing to the wrong file
* several additional properties incorrectly retained IDs, and this PR removes them. 