### PR TITLE
Docker & bump to slicedimage 0.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+## Dockerfile for sptx
+##
+## Default entrypoint is the validate-sptx script.
+
+FROM continuumio/miniconda3
+RUN useradd -m sptx
+USER sptx
+
+# Set up the initial conda environment
+COPY --chown=sptx:sptx environment.yml /src/environment.yml
+WORKDIR /src
+RUN conda env create -f environment.yml
+
+# Prepare for build
+COPY --chown=sptx:sptx . /src
+RUN echo "source activate sptx" >> ~/.bashrc
+ENV PATH /home/sptx/.conda/envs/sptx/bin:$PATH
+
+# Build and configure for running
+RUN pip install -e .
+
+env MPLBACKEND Agg
+ENTRYPOINT ["validate-sptx"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include schema/ *.json
+recursive-include examples/ *.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include schema/ *.json

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,6 +1,7 @@
+# Also update environment.yml
 click
 flake8
 jsonschema
 mypy
 pytest
-slicedimage == 0.0.1
+slicedimage == 0.0.3

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -3,4 +3,4 @@ flake8
 jsonschema
 mypy
 pytest
-slicedimage == 0.0.0-dev21
+slicedimage == 0.0.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+name: sptx
+channels:
+- defaults
+- bioconda
+- conda-forge
+dependencies:
+- python>=3.6
+- click
+- flake8
+- jsonschema
+- mypy
+- pytest
+- slicedimage==0.0.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,4 @@
+# Also update REQUIREMENTS.txt
 name: sptx
 channels:
 - defaults

--- a/validate_sptx/validate_sptx.py
+++ b/validate_sptx/validate_sptx.py
@@ -24,7 +24,7 @@ def validate_sptx(experiment_json: str) -> None:
 
     # use slicedimage to read the top-level experiment json file passed by the user
     backend, name, baseurl = resolve_path_or_url(experiment_json)
-    with backend.read_file_handle(name) as fh:
+    with backend.read_contextmanager(name) as fh:
         experiment = json.load(fh)
 
     # validate experiment.json
@@ -34,13 +34,13 @@ def validate_sptx(experiment_json: str) -> None:
     # validate manifests that it links to.
     possible_manifests = []
     manifest_validator = SpaceTxValidator(_get_absolute_schema_path('fov_manifest.json'))
-    with backend.read_file_handle(experiment['hybridization_images']) as fh:
+    with backend.read_contextmanager(experiment['hybridization_images']) as fh:
         possible_manifests.append(json.load(fh))
 
     # loop over all the manifests that are stored in auxiliary images. Disallowed names will
     # have already been excluded by experiment validation.
     for manifest in experiment['auxiliary_images'].values():
-        with backend.read_file_handle(manifest) as fh:
+        with backend.read_contextmanager(manifest) as fh:
             possible_manifests.append(json.load(fh))
 
     # we allow the objects linked from hybridization_images and auxiliary images to either be
@@ -53,7 +53,7 @@ def validate_sptx(experiment_json: str) -> None:
 
             # contains fields of view
             for fov in manifest['contents']:
-                with backend.read_file_handle(fov) as fh:
+                with backend.read_contextmanager(fov) as fh:
                     fovs.append(json.load(fh))
 
         else:  # manifest is a field of view
@@ -67,7 +67,7 @@ def validate_sptx(experiment_json: str) -> None:
 
     # validate codebook
     codebook_validator = SpaceTxValidator(_get_absolute_schema_path('codebook/codebook.json'))
-    with backend.read_file_handle(experiment['codebook']) as fh:
+    with backend.read_contextmanager(experiment['codebook']) as fh:
         codebook = json.load(fh)
     valid &= codebook_validator.validate_object(codebook)
 


### PR DESCRIPTION
This is something of a grab bag while I test validation. Additionally, code is going to be migrating, etc. etc., so feel to take what you'd like and leave the rest. Various issues:

 * [x] schema files aren't found after `pip install` --> `MANIFEST.in`
 * [x] simplified install --> slicedimage 0.0.3
 * [x] `'DiskBackend' object has no attribute 'read_file_handle'` --> `read_contextmanager`
 * [ ] Currently looking into: `[Errno 2] No such file or directory: '/data/merfish-2018082-a/fov_000'`

where `merfish-2018082-a` is the output from https://github.com/spacetx/starfish/pull/478