### PR TITLE
Use the value of the contents map

### DIFF
--- a/validate_sptx/validate_sptx.py
+++ b/validate_sptx/validate_sptx.py
@@ -52,7 +52,7 @@ def validate_sptx(experiment_json: str) -> None:
             valid &= manifest_validator.validate_object(manifest)
 
             # contains fields of view
-            for fov in manifest['contents']:
+            for key, fov in manifest['contents'].items():
                 with backend.read_contextmanager(fov) as fh:
                     fovs.append(json.load(fh))
 


### PR DESCRIPTION
Without this change, "No such file or directory" is raised
for the the fov name, e.g. `fov_000` in:

```
    "contents": {
        "fov_000": "hybridization-fov_000.json"
    },
```