### PR TITLE
Validation output improvements

### DIFF
--- a/validate_sptx/test_field_of_view.py
+++ b/validate_sptx/test_field_of_view.py
@@ -26,6 +26,11 @@ def test_dartfish_nuclei_example_field_of_view():
     )
     assert validator.validate_file(dartfish_example_path)
 
+def test_fov_must_be_present():
+    no_fov = validator.load_json(example)
+    del no_fov['fov']
+    with pytest.warns(UserWarning):
+        assert not validator.validate_object(no_fov)
 
 def test_channel_must_be_present():
     no_channel = validator.load_json(example)

--- a/validate_sptx/test_field_of_view.py
+++ b/validate_sptx/test_field_of_view.py
@@ -26,11 +26,13 @@ def test_dartfish_nuclei_example_field_of_view():
     )
     assert validator.validate_file(dartfish_example_path)
 
+
 def test_fov_must_be_present():
     no_fov = validator.load_json(example)
     del no_fov['fov']
     with pytest.warns(UserWarning):
         assert not validator.validate_object(no_fov)
+
 
 def test_channel_must_be_present():
     no_channel = validator.load_json(example)

--- a/validate_sptx/validate_sptx.py
+++ b/validate_sptx/validate_sptx.py
@@ -3,7 +3,10 @@ import os
 import sys
 
 import click
+
 from slicedimage.io import resolve_path_or_url
+
+from typing import Dict
 
 from .util import SpaceTxValidator, package_root
 
@@ -67,9 +70,12 @@ def validate_sptx(experiment_json: str) -> None:
 
     # validate codebook
     codebook_validator = SpaceTxValidator(_get_absolute_schema_path('codebook/codebook.json'))
-    with backend.read_contextmanager(experiment['codebook']) as fh:
-        codebook = json.load(fh)
-    valid &= codebook_validator.validate_object(codebook, experiment['codebook'])
+    codebook_file = experiment.get('codebook')
+    codebook: Dict = {}
+    if codebook_file is not None:
+        with backend.read_contextmanager(codebook) as fh:
+            codebook = json.load(fh)
+    valid &= codebook_validator.validate_object(codebook, codebook_file)
 
     if valid:
         sys.exit(0)

--- a/validate_sptx/validate_sptx.py
+++ b/validate_sptx/validate_sptx.py
@@ -54,22 +54,22 @@ def validate_sptx(experiment_json: str) -> None:
             # contains fields of view
             for key, fov in manifest['contents'].items():
                 with backend.read_contextmanager(fov) as fh:
-                    fovs.append(json.load(fh))
+                    fovs.append((json.load(fh), fov))
 
         else:  # manifest is a field of view
-            fovs.append(manifest)
+            fovs.append((manifest, None))
 
     # validate fovs
     assert len(fovs) != 0
     fov_validator = SpaceTxValidator(_get_absolute_schema_path('field_of_view/field_of_view.json'))
-    for fov in fovs:
-        valid &= fov_validator.validate_object(fov)
+    for fov, filename in fovs:
+        valid &= fov_validator.validate_object(fov, filename)
 
     # validate codebook
     codebook_validator = SpaceTxValidator(_get_absolute_schema_path('codebook/codebook.json'))
     with backend.read_contextmanager(experiment['codebook']) as fh:
         codebook = json.load(fh)
-    valid &= codebook_validator.validate_object(codebook)
+    valid &= codebook_validator.validate_object(codebook, experiment['codebook'])
 
     if valid:
         sys.exit(0)


### PR DESCRIPTION
 * ~~drop `warnings` for legibility~~
 * include filename when possible
 * include schema $id

```
Errors in: hybridization-fov_000.json
 'fov' is a required property
	Schema:         	https://github.com/spacetx/sptx-format/schema/field_of_view/field_of_view.json
	Subschema level:	0
	Path to error:  	required

Errors in: nuclei-fov_000.json
 'fov' is a required property
	Schema:         	https://github.com/spacetx/sptx-format/schema/field_of_view/field_of_view.json
	Subschema level:	0
	Path to error:  	required
```