### PR TITLE
Remove the fov id from the field of view manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ The below example describes a 2-channel, 8-round coded experiment that samples a
 ```json
 {
   "version": "0.0.0",
-  "fov": 0,
   "dimensions": [
       "x",
       "y",

--- a/examples/field_of_view/dartfish_field_of_view.json
+++ b/examples/field_of_view/dartfish_field_of_view.json
@@ -16,7 +16,6 @@
         "r": 6,
         "z": 1
     },
-    "fov": 0,
     "tiles": [
         {
             "coordinates": {

--- a/examples/field_of_view/dartfish_nuclei.json
+++ b/examples/field_of_view/dartfish_nuclei.json
@@ -16,7 +16,6 @@
         "r": 1,
         "z": 1
     },
-    "fov": 0,
     "tiles": [
         {
             "coordinates": {

--- a/examples/field_of_view/field_of_view.json
+++ b/examples/field_of_view/field_of_view.json
@@ -1,6 +1,5 @@
 {
   "version": "0.0.0",
-  "fov": 0,
   "dimensions": [
       "x",
       "y",

--- a/schema/field_of_view/field_of_view.json
+++ b/schema/field_of_view/field_of_view.json
@@ -6,7 +6,6 @@
     "version",
     "dimensions",
     "shape",
-    "fov",
     "tiles"
   ],
   "additionalProperties": false,
@@ -67,14 +66,6 @@
           ]
         }
       }
-    },
-    "fov": {
-      "type": "integer",
-      "minimum": 0,
-      "description": "Identifies the index of this field of view within a larger experiment.",
-      "examples": [
-        0, 1, 4
-      ]
     },
     "tiles": {
       "minItems": 1,


### PR DESCRIPTION
They are redundant since the field of view manifests are indexed by their name already.

With this change, https://github.com/spacetx/slicedimage/pull/55 *should* no longer be necessary.